### PR TITLE
wip: add two students to seating chart

### DIFF
--- a/WebApp.Tests/ClassPeriodTests.cs
+++ b/WebApp.Tests/ClassPeriodTests.cs
@@ -96,7 +96,7 @@ namespace WebApp.Tests
         {
             //given a Default classroom: 4x4
             var defaultStudent = new StudentName("first", "student");
-            var secondStudent = new StudentName("another", "student");
+            var secondStudent = new StudentName("another", "pupil");
 
             var result = DefaultClassPeriod.AddStudent(defaultStudent);
 

--- a/WebApp.Tests/ClassPeriodTests.cs
+++ b/WebApp.Tests/ClassPeriodTests.cs
@@ -92,6 +92,25 @@ namespace WebApp.Tests
         }
 
         [Fact]
+        public void ClassPeriod_AddTwoStudents_PutsStudentsInCorrectPlaces()
+        {
+            //given a Default classroom: 4x4
+            var defaultStudent = new StudentName("first", "student");
+            var secondStudent = new StudentName("another", "student");
+
+            var result = DefaultClassPeriod.AddStudent(defaultStudent);
+
+            //when 
+            result = DefaultClassPeriod.AddStudent(secondStudent);
+
+            //then
+            result.ShouldBeTrue();
+            var chart = DefaultClassPeriod.GetClassroomSeatingChart();
+            chart[0,1].ShouldBe("x");
+            chart[0,2].ShouldBe(DefaultClassPeriod.Students[1].FullName);
+        }
+
+        [Fact]
         public void ClassPeriod_CanAddStudentsUntilLimitIsReached()
         {
             //given 

--- a/WebApp/Helpers/ClassPeriod.cs
+++ b/WebApp/Helpers/ClassPeriod.cs
@@ -91,7 +91,13 @@ namespace WebApp.Helpers
 
         private (int rows, int columns) GetInsertPosition()
         {
+            //TODO: prepare chart for insert, such as shifting it to insert after full
+
+            var count = Students.Count() - 1;
             
+            if(count == 1)
+                return (0, 2);
+            else     
             return (0, 0);
         }
 

--- a/WebApp/Helpers/ClassPeriod.cs
+++ b/WebApp/Helpers/ClassPeriod.cs
@@ -50,7 +50,7 @@ namespace WebApp.Helpers
         public ClassPeriod(int rows, int columns, StudentName[] students) :
             this(rows, columns)
         {
-            
+
             foreach (StudentName studentName in students)
             {
                 if (!AddStudent(studentName))
@@ -71,34 +71,49 @@ namespace WebApp.Helpers
         /// <returns></returns>
         public bool AddStudent(StudentName studentName)
         {
+            var canAddStudent = Students.Count < Size;
             if (Students.Count < Size)
             {
-                Students.Add(studentName);
-                UpdateChart(studentName);
 
-                return true;
+                UpdateChart(studentName);
+                Students.Add(studentName);
+                
             }
-            return false;
+            return canAddStudent;
         }
 
         private void UpdateChart(StudentName studentName)
         {
-            //needs to be updated to reflect expected insert behavior
+            var updatedChart = CreateUpdatedSeatingChart(studentName);
+            Chart = updatedChart;
+        }
+
+        private string[,] CreateUpdatedSeatingChart(StudentName studentName)
+        {
+
+            //TODO: move this to a dedicated class/module
+
+            var seatingChart = Chart;
+            //TODO: prepare chart for insert, such as shifting it to insert after full
             (int rows, int columns) = GetInsertPosition();
 
-            Chart[rows, columns] = studentName.FullName;
+            seatingChart[rows, columns] = studentName.FullName;
+            return seatingChart;
         }
 
         private (int rows, int columns) GetInsertPosition()
         {
-            //TODO: prepare chart for insert, such as shifting it to insert after full
+            //handle basic scenario: return the first cell that contains an 'x' and follows an 'x'
+            //second basic scenario: return the first 'x' cell in the next row
+            // if first 'x' cell in next row is adjacent to a filled cell in row below, shift right or up if possible
+            //
 
-            var count = Students.Count() - 1;
-            
-            if(count == 1)
+            if (Students.Count == 1)
+            {
                 return (0, 2);
-            else     
-            return (0, 0);
+            }
+            else
+                return (0, 0);
         }
 
         public string[,] GetClassroomSeatingChart()
@@ -106,6 +121,4 @@ namespace WebApp.Helpers
             return Chart;
         }
     }
-
-
 }


### PR DESCRIPTION
when complete, should allow a 2nd student name to be displayed in ClassPeriod seating chart.
implementation plan: 
- get ClassPeriod with 2 names to be displayed correctly in the following grids: 
  - a 4x4 grid (first | x | second)
  - also test 1x2 (first | second )
  - and 2x1 (first // second )