### PR TITLE
implements fill for 2nd student

### DIFF
--- a/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
+++ b/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
@@ -30,6 +30,20 @@ public class SeatingChart_AltFill_TwoStudents_Tests
         student.ShouldBe(Students[0].FullName);
     }
 
-    
+
+    [Theory]
+    [InlineData(1, 2, 0, 1)] // 1x2 grid should put 2nd student into [0,1]
+    public void SecondStudentTakesCorrectPlaceInChart(int rows, int columns, int expectedRowIndex, int expectedColumnIndex)
+    {
+        //given
+        var seatingChart = new SeatingChart(rows, columns, Students, useAlternateFill: true);
+
+        //when
+        var student = seatingChart.Chart[expectedRowIndex, expectedColumnIndex];
+
+        //then
+        student.ShouldBe(Students[1].FullName);
+    }
+
 
 }

--- a/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
+++ b/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
@@ -33,6 +33,7 @@ public class SeatingChart_AltFill_TwoStudents_Tests
 
     [Theory]
     [InlineData(1, 2, 0, 1)] // 1x2 grid should put 2nd student into [0,1]
+    [InlineData(2, 1, 1, 0)] // 2x1 grid should put 2nd student into [1,0]
     public void SecondStudentTakesCorrectPlaceInChart(int rows, int columns, int expectedRowIndex, int expectedColumnIndex)
     {
         //given

--- a/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
+++ b/WebApp.Tests/SeatingChart/SeatingChart_AltFill_TwoStudents_Tests.cs
@@ -1,0 +1,35 @@
+﻿using Shouldly;
+using WebApp.Helpers;
+
+namespace WebApp.Tests;
+
+public class SeatingChart_AltFill_TwoStudents_Tests
+{
+    public SeatingChart_AltFill_TwoStudents_Tests() 
+    {
+        Students = new List<StudentName> {
+            new StudentName("first", "student"),
+            new StudentName("next", "pupil")
+        };
+    }
+
+    public List<StudentName> Students { get; }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SecondStudentIsIgnored_In_1x1_Chart(bool useAltFill) 
+    {
+        //given 
+        var seatingChart = new SeatingChart(1, 1, Students, useAltFill);
+
+        //when
+        var student = seatingChart.Chart[0,0];
+
+        //then
+        student.ShouldBe(Students[0].FullName);
+    }
+
+    
+
+}

--- a/WebApp.Tests/SeatingChartTests.cs
+++ b/WebApp.Tests/SeatingChartTests.cs
@@ -122,7 +122,7 @@ public class SeatingChartTests
         var seatingChart = DefaultOneByOneSeatingChart;
 
         //when
-        bool spotIsCrowded = seatingChart.IsCrowded(0, 0);
+        bool spotIsCrowded = SeatingChart.IsCrowded(seatingChart.Chart, 0, 0);
 
         //then
         spotIsCrowded.ShouldBeFalse();
@@ -136,8 +136,8 @@ public class SeatingChartTests
         seatingChart.Chart[0, 0] = "asdf";
 
         //when
-        bool isFilled = seatingChart.SeatIsFilled(0, 0);
-        bool spotIsCrowded = seatingChart.IsCrowded(0, 0);
+        bool isFilled = SeatingChart.SeatIsFilled(seatingChart.Chart, 0, 0);
+        bool spotIsCrowded = SeatingChart.IsCrowded(seatingChart.Chart, 0, 0);
 
         //then
         isFilled.ShouldBeTrue();
@@ -152,7 +152,7 @@ public class SeatingChartTests
         (int row, int col) = (0, 0);
 
         //when
-        var open = !seatingChart.IsSeatRightFilled(row, col);
+        var open = !SeatingChart.IsSeatRightFilled(seatingChart.Chart, row, col);
 
         //then
         open.ShouldBeTrue();
@@ -171,7 +171,7 @@ public class SeatingChartTests
         (int row, int col) = (0, 0);
 
         //then
-        seatingChart.IsSeatRightFilled(0, 0).ShouldBe(expectedResult);
+        SeatingChart.IsSeatRightFilled(seatingChart.Chart, 0, 0).ShouldBe(expectedResult);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class SeatingChartTests
         (int row, int col) = (1, 1);
 
         //when
-        var isRightSeatOpen = !seatingChart.IsSeatRightFilled(row, col);
+        var isRightSeatOpen = !SeatingChart.IsSeatRightFilled(seatingChart.Chart, row, col);
 
         //then
         isRightSeatOpen.ShouldBeTrue();
@@ -201,7 +201,7 @@ public class SeatingChartTests
             for (int j = 0; j < 3; j++)
             {
                 //then
-                seatingChart.IsSeatRightFilled(i, j).ShouldBeFalse();
+                SeatingChart.IsSeatRightFilled(seatingChart.Chart, i, j).ShouldBeFalse();
             }
         }
 

--- a/WebApp.Tests/SeatingChart_FillChart_Tests.cs
+++ b/WebApp.Tests/SeatingChart_FillChart_Tests.cs
@@ -51,4 +51,19 @@ public class SeatingChart_FillChart_Tests
         //then
         firstStudent.ShouldBe(Students[index].FullName);
     }
+
+    [Fact]
+    public void AlternateFill_DoesNotOverfill_1x1_Chart()
+    {
+        //given 
+        var seatingChart = new SeatingChart(1,1, Students.ToList(), useAlternateFill: true);
+
+        //when
+        var firstStudent = seatingChart.Chart[0,0];
+
+        //then
+        firstStudent.ShouldBe(Students[0].FullName);
+        
+    }
+
 }

--- a/WebApp/Helpers/SeatingChart.cs
+++ b/WebApp/Helpers/SeatingChart.cs
@@ -1,301 +1,334 @@
 
+namespace WebApp.Helpers;
 
-namespace WebApp.Helpers
+//Seating chart assumes the students are already sorted? 
+// implementation plan: 
+// crud:
+/* Create: creates a new SeatingChart object with a sorted list of students
+ * Update: Add => Add a student to the mix. seatingchart doesn't know how to sort. would we want it to add? No. 
+ *          maybe SeatingChart should be immutable. You create it with a sorted list and dimensions. 
+ *          on update, create another one? against this on a basic efficiency basis. need to test? 
+ *                  test performance
+                        - hypothesis: recreating object (new SeatingChart(rows, columns, newSortedListOfStudents) 
+                                        doesn't take much longer than changing the array values.
+
+ * expected behavior: add a node if nothing adjacent... can we test THAT?
+ *  given a seating chart of dimensions Rows*Columns, Insert operation should... 
+ *      1. place the inserted item in the lowest spot. 
+ *      2. if the lowest spot is taken, then take the next spot over, as long as there's not anyone adjacent?
+ *          - this looks like a double shift for 
+ *      3. behavior before filling front before back that SHOULD work before the gaps disappear:
+            - start at zero
+                - if empty, fill with name
+            - move left 1, if possible, up if possible. 
+            - this feels like making a 1D array into a 2d array [NAME x x x x x] becomes [NAME x NAME x x x] but can shift depending on shape?
+            - alternative is to not shift at all, but to keep an insert spot precalculated, but may still need to shift... 
+            - can we make a 2D array into a 1D array?  this seems like a key behavior for filling front before back... 
+                - can we shift a 2D array? NO... :(
+            - if 'x', 
+                - check left, right, up, and down for name or out of bounds
+                - if left/right/up/down are "empty", ok to insert, 
+                - else, note first 'x' and keep walking
+ */
+public class SeatingChart
 {
-    //Seating chart assumes the students are already sorted? 
-    // implementation plan: 
-    // crud:
-    /* Create: creates a new SeatingChart object with a sorted list of students
-     * Update: Add => Add a student to the mix. seatingchart doesn't know how to sort. would we want it to add? No. 
-     *          maybe SeatingChart should be immutable. You create it with a sorted list and dimensions. 
-     *          on update, create another one? against this on a basic efficiency basis. need to test? 
-     *                  test performance
-                            - hypothesis: recreating object (new SeatingChart(rows, columns, newSortedListOfStudents) 
-                                            doesn't take much longer than changing the array values.
+    private Tuple<int, int> OpenSeat;
+    public int Rows { get; }
+    public int Columns { get; }
+    public string[,] Chart { get; private set; }
 
-     * expected behavior: add a node if nothing adjacent... can we test THAT?
-     *  given a seating chart of dimensions Rows*Columns, Insert operation should... 
-     *      1. place the inserted item in the lowest spot. 
-     *      2. if the lowest spot is taken, then take the next spot over, as long as there's not anyone adjacent?
-     *          - this looks like a double shift for 
-     *      3. behavior before filling front before back that SHOULD work before the gaps disappear:
-                - start at zero
-                    - if empty, fill with name
-                - move left 1, if possible, up if possible. 
-                - this feels like making a 1D array into a 2d array [NAME x x x x x] becomes [NAME x NAME x x x] but can shift depending on shape?
-                - alternative is to not shift at all, but to keep an insert spot precalculated, but may still need to shift... 
-                - can we make a 2D array into a 1D array?  this seems like a key behavior for filling front before back... 
-                    - can we shift a 2D array? NO... :(
-                - if 'x', 
-                    - check left, right, up, and down for name or out of bounds
-                    - if left/right/up/down are "empty", ok to insert, 
-                    - else, note first 'x' and keep walking
-     */
-    public class SeatingChart
+    private const string EmptySpaceSymbol = "x";
+    private readonly List<StudentName> Students;
+
+    public SeatingChart(int rows, int columns, List<StudentName> students, bool useAlternateFill = false)
     {
-        private Tuple<int, int> OpenSeat;
-        public int Rows { get; }
-        public int Columns { get; }
-        public string[,] Chart { get; private set; }
+        Rows = rows;
+        Columns = columns;
+        Chart = CreateDefaultSeatingChart(rows, columns);
+        Students = students;
+        OpenSeat = new Tuple<int, int>(0, 0);
 
-        private const string EmptySpaceSymbol = "x";
-        private readonly List<StudentName> Students;
+        FillChartWithStudents();
 
-        public SeatingChart(int rows, int columns, List<StudentName> students, bool useAlternateFill = false)
+        if (useAlternateFill)
         {
-            Rows = rows;
-            Columns = columns;
-            Chart = CreateDefaultSeatingChart(rows, columns);
-            Students = students;
-            OpenSeat = new Tuple<int, int>(0, 0);
-
-            FillChartWithStudents();
-
-            if (useAlternateFill)
-            {
-                Chart = DistributeStudents(Chart, Students);
-            }
-
-        }
-
-        private string[,] DistributeStudents(string[,] chart, List<StudentName> students)
-        {
-
-            var newChart = CreateDefaultSeatingChart(Rows, Columns);
-
-            
-            for (int i = 0; i < Students.Count; i++)
-            {
-                var studentName = Students[i];
-                (int row, int col) = GetFirstEmptySeat();
-
-                Chart[row, col] = studentName.FullName;
-            }
-
-            // (int row, int column) = GetFirstEmptyUncrowdedSeat();
-            // bool everythingCrowded = row < 0 && column < 0;
-
-            return chart;
-
-
-            /*
-            * alternate approach to filling front before back:
-            * when no more uncrowded spots, collapse everything
-            * to fill first row. distribute everyone else in the remaining rows.
-            * - this can probably be done by simulating a seating chart with omitted students
-            * -- basically, if no more uncrowded spots, 
-                - fill first row by shifting everything to top left
-                - once first row is full, 
-                    - take all remaining names (subset of students)
-                    - create a new seating chart that's minus one row, fill with remaining names
-                    - get its output seating chart and replace remaining rows
-                    - do so until .... we're in the last spot
-
-                    given: students[0..10]
-                    return a new seating chart where 
-                        the first row consists of students[0..columns]
-                        and the rest consists of the same approach with a chart minus 1 row and remaining students
-            */
-
-        }
-
-        private static string[,] CreateDefaultSeatingChart(int rows, int columns)
-        {
-            //TODO: make this a view responsibility
-
-            var chart = new string[rows, columns];
-
-            for (int i = 0; i < rows; i++)
-                for (int j = 0; j < columns; j++)
-                    chart[i, j] = EmptySpaceSymbol;
-
-            return chart;
-        }
-
-        public static SeatingChart CollapseFullSeatingChart(SeatingChart seatingChart)
-        {
-            //use this method to collapse seating charts.
-            //there's some function that can take a list of student names and a chart and spit one out that is collapsed
-            //it would be like
-            /*  func collapseFirstRow(numRows, numColumns, students)
-                {
-                    //returns a new chart with the first row filled and the rest ... distributed?
-
-                    remainingStudents = students[numColumns...] 
-                    firstRowStudents = students[0..numColumns]
-                    var firstRowSeatingChart = new SeatingChart(1, columns, firstRowStudents);
-                    var firstRowChart = firstRowSeatingChart.Chart;
-                    var newSeatingChart = new SeatingChart(numRows - 1, columns, remainingStudents}
-
-                    return some amalgam of the current row that just got collapsed
-                    AND the remaining rows.
-
-
-                } */
-
-            return seatingChart;
-        }
-
-        private int GetIndexFromRowAndColumn(int row, int column, int columns)
-        {
-            return row * columns + column;
-        }
-
-        private void FillChartWithStudents()
-        {
-            string[,] chart = CreateDefaultSeatingChart(Rows, Columns);
-            Chart = FillChartWithStudents(chart);
-
-        }
-
-        private string[,] FillChartWithStudents(string[,] emptyChart)
-        {
-            var chart = emptyChart;
-
-            //TODO: deal with waitlist or trim students?
-            for (int i = 0; i < Rows; i++)
-            {
-                for (int j = 0; j < Columns; j++)
-                {
-                    var studentIndex = GetIndexFromRowAndColumn(i, j, Columns);
-                    if (studentIndex < Students.Count)
-                    {
-                        chart[i, j] = Students[studentIndex].FullName;
-                    }
-                    else
-                    {
-                        break;
-                    }
-
-                }
-            }
-
-            return chart;
-        }
-
-        public (int, int) GetFirstEmptyUncrowdedSeat(string[,] chart, int rows, int columns)
-        {
-            //walk each row left to right and find the first spot that isn't filled
-            for (int i = 0; i < rows; i++)
-            {
-                for (int j = 0; j < columns; j++)
-                {
-                    if (chart[i, j] == "x" && !IsCrowded(i, j))
-                    {
-                        return (i, j);
-                    }
-                }
-            }
-            return (-1, -1);
-        }
-        public bool IsSeatEmpty(int row, int column)
-        {
-            bool empty = Chart[row, column] == "x";
-            return empty &&
-                    (Students.Count == 0 || (row > 0 && column > 0));
-
-            //walk each row left to right and find the first spot that isn't filled
-        }
-
-        public (int, int) GetFirstEmptySeat()
-        {
-            (int row, int col) = GetFirstEmptySeat(Chart, Rows, Columns);
-            OpenSeat = new Tuple<int, int>(row, col);
-
-            return (row, col);
-        }
-
-        private static (int, int) GetFirstEmptySeat(string[,] chart, int rows, int columns)
-        {
-            //TODO: possibly move to a SeatingChartFiller class or module?
-            //walk each row left to right and find the first spot that isn't filled
-            for (int i = 0; i < rows; i++)
-            {
-                for (int j = 0; j < columns; j++)
-                {
-                    if (chart[i, j] == "x")
-                    {
-                        return (i, j);
-                    }
-                }
-            }
-
-            return (-1, -1);
-        }
-
-        public bool HasEmptySpot()
-        {
-            for (var i = 0; i < Rows; i++)
-            {
-                for (var j = 0; j < Columns; j++)
-                {
-                    if (Chart[i, j] == "x")
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-
-        public bool IsCrowded(int row, int column)
-        {
-            return IsSeatAheadFilled(row, column)
-                    || IsSeatBehindFilled(row, column)
-                    || IsSeatLeftFilled(row, column)
-                    || IsSeatRightFilled(row, column);
-        }
-
-        public bool IsSeatRightFilled(int row, int col)
-        {
-            //right = col + 1
-            return SeatIsFilled(row, col, columnOffset: 1);
-        }
-
-        public bool IsSeatLeftFilled(int row, int column)
-        {
-            //left = column - 1
-            return SeatIsFilled(row, column, columnOffset: -1);
-        }
-
-        public bool IsSeatBehindFilled(int rowIndex, int columnIndex)
-        {
-            //back = row + 1 
-            return SeatIsFilled(rowIndex, columnIndex, rowOffset: 1);
-        }
-
-        public bool IsSeatAheadFilled(int row, int column)
-        {
-            //ahead = row - 1
-            return SeatIsFilled(row, column, rowOffset: -1);
-        }
-
-        public bool SeatIsAvailable(int row, int column, int rowOffset = 0, int columnOffset = 0)
-        {
-            var rowIndex = row + rowOffset;
-            var columnIndex = column + columnOffset;
-
-            return SeatIsInbound(rowIndex, columnIndex)
-                    && Chart[rowIndex, columnIndex] == "x";
-        }
-
-        public bool SeatIsFilled(int row, int column, int rowOffset = 0, int columnOffset = 0)
-        {
-            var rowIndex = row + rowOffset;
-            var columnIndex = column + columnOffset;
-
-            return SeatIsInbound(rowIndex, columnIndex)
-                    && Chart[rowIndex, columnIndex] != "x";
-        }
-
-        public bool SeatIsInbound(int row, int column)
-        {
-            return row > 0 && row < Chart.GetLength(0) 
-             && column > 0 && column < Chart.GetLength(1);
-            
+            Chart = DistributeStudents(Chart, Students);
         }
 
     }
+
+    private string[,] DistributeStudents(string[,] chart, List<StudentName> students)
+    {
+
+        var newChart = CreateDefaultSeatingChart(Rows, Columns);
+
+
+        for (int i = 0; i < Students.Count; i++)
+        {
+            var studentName = Students[i];
+            (int row, int col) = GetFirstEmptySeat();
+
+            var isCrowded = IsCrowded(chart, row, col);
+
+            if (isCrowded)
+            {
+
+                //get next available spot and update row/col if needed
+                (int newRow, int newCol) = GetFirstEmptyUncrowdedSeat(newChart);
+
+                if (newRow != -1 && newCol != -1)
+                {
+                    //there's an empty uncrowded seat
+                    
+                    row = newRow;
+                    col = newCol;
+                }
+                else {
+                    //there are no more empty uncrowded seats
+                    //TODO, collapse chart and try again with a smaller chart subset
+                }
+
+            }
+
+            chart[row, col] = studentName.FullName;
+        }
+
+        // (int row, int column) = GetFirstEmptyUncrowdedSeat();
+        // bool everythingCrowded = row < 0 && column < 0;
+
+        return chart;
+
+
+        /*
+        * alternate approach to filling front before back:
+        * when no more uncrowded spots, collapse everything
+        * to fill first row. distribute everyone else in the remaining rows.
+        * - this can probably be done by simulating a seating chart with omitted students
+        * -- basically, if no more uncrowded spots, 
+            - fill first row by shifting everything to top left
+            - once first row is full, 
+                - take all remaining names (subset of students)
+                - create a new seating chart that's minus one row, fill with remaining names
+                - get its output seating chart and replace remaining rows
+                - do so until .... we're in the last spot
+
+                given: students[0..10]
+                return a new seating chart where 
+                    the first row consists of students[0..columns]
+                    and the rest consists of the same approach with a chart minus 1 row and remaining students
+        */
+
+    }
+
+    private static string[,] CreateDefaultSeatingChart(int rows, int columns)
+    {
+        //TODO: make this a view responsibility
+
+        var chart = new string[rows, columns];
+
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < columns; j++)
+                chart[i, j] = EmptySpaceSymbol;
+
+        return chart;
+    }
+
+    public static SeatingChart CollapseFullSeatingChart(SeatingChart seatingChart)
+    {
+        //use this method to collapse seating charts.
+        //there's some function that can take a list of student names and a chart and spit one out that is collapsed
+        //it would be like
+        /*  func collapseFirstRow(numRows, numColumns, students)
+            {
+                //returns a new chart with the first row filled and the rest ... distributed?
+
+                remainingStudents = students[numColumns...] 
+                firstRowStudents = students[0..numColumns]
+                var firstRowSeatingChart = new SeatingChart(1, columns, firstRowStudents);
+                var firstRowChart = firstRowSeatingChart.Chart;
+                var newSeatingChart = new SeatingChart(numRows - 1, columns, remainingStudents}
+
+                return some amalgam of the current row that just got collapsed
+                AND the remaining rows.
+
+
+            } */
+
+        return seatingChart;
+    }
+
+    private int GetIndexFromRowAndColumn(int row, int column, int columns)
+    {
+        return row * columns + column;
+    }
+
+    private void FillChartWithStudents()
+    {
+        string[,] chart = CreateDefaultSeatingChart(Rows, Columns);
+        Chart = FillChartWithStudents(chart);
+
+    }
+
+    private string[,] FillChartWithStudents(string[,] emptyChart)
+    {
+        var chart = emptyChart;
+
+        //TODO: deal with waitlist or trim students?
+        for (int i = 0; i < Rows; i++)
+        {
+            for (int j = 0; j < Columns; j++)
+            {
+                var studentIndex = GetIndexFromRowAndColumn(i, j, Columns);
+                if (studentIndex < Students.Count)
+                {
+                    chart[i, j] = Students[studentIndex].FullName;
+                }
+                else
+                {
+                    break;
+                }
+
+            }
+        }
+
+        return chart;
+    }
+
+    public (int, int) GetFirstEmptyUncrowdedSeat(string[,] chart)
+    {
+        var rows = chart.GetLength(0);
+        var columns = chart.GetLength(1);
+
+        //walk each row left to right and find the first spot that isn't filled
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < columns; j++)
+            {
+                if (chart[i, j] == "x" && !IsCrowded(chart, i, j))
+                {
+                    return (i, j);
+                }
+            }
+        }
+        return (-1, -1);
+    }
+    public bool IsSeatEmpty(int row, int column)
+    {
+        bool empty = Chart[row, column] == "x";
+        return empty &&
+                (Students.Count == 0 || (row > 0 && column > 0));
+
+        //walk each row left to right and find the first spot that isn't filled
+    }
+
+    public (int, int) GetFirstEmptySeat()
+    {
+        (int row, int col) = GetFirstEmptySeat(Chart, Rows, Columns);
+        OpenSeat = new Tuple<int, int>(row, col);
+
+        return (row, col);
+    }
+
+    private static (int, int) GetFirstEmptySeat(string[,] chart, int rows, int columns)
+    {
+        //TODO: possibly move to a SeatingChartFiller class or module?
+        //walk each row left to right and find the first spot that isn't filled
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < columns; j++)
+            {
+                if (chart[i, j] == "x")
+                {
+                    return (i, j);
+                }
+            }
+        }
+
+        return (-1, -1);
+    }
+
+    public bool HasEmptySpot()
+    {
+        for (var i = 0; i < Rows; i++)
+        {
+            for (var j = 0; j < Columns; j++)
+            {
+                if (Chart[i, j] == "x")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+
+    public static bool IsCrowded(string[,] chart, int row, int column)
+    {
+        return IsSeatAheadFilled(chart, row, column)
+                || IsSeatBehindFilled(chart, row, column)
+                || IsSeatLeftFilled(chart, row, column)
+                || IsSeatRightFilled(chart, row, column);
+    }
+
+    public static bool IsSeatRightFilled(string[,] chart, int row, int col)
+    {
+        //right = col + 1
+        return SeatIsFilled(chart, row, col, columnOffset: 1);
+    }
+
+    public static bool IsSeatLeftFilled(string[,] chart, int row, int column)
+    {
+        //left = column - 1
+        return SeatIsFilled(chart, row, column, columnOffset: -1);
+    }
+
+    public static bool IsSeatBehindFilled(string[,] chart, int rowIndex, int columnIndex)
+    {
+        //back = row + 1 
+        return SeatIsFilled(chart, rowIndex, columnIndex, rowOffset: 1);
+    }
+
+    public static bool IsSeatAheadFilled(string[,] chart, int row, int column)
+    {
+        //ahead = row - 1
+        return SeatIsFilled(chart, row, column, rowOffset: -1);
+    }
+
+    public static bool SeatIsInboundAndAvailable(string[,] chart, int row, int column, int rowOffset = 0, int columnOffset = 0)
+    {
+        var rowIndex = row + rowOffset;
+        var columnIndex = column + columnOffset;
+
+        return SeatIsInbound(chart, rowIndex, columnIndex)
+                && !SeatIsInboundAndFilled(chart, rowIndex, columnIndex);
+    }
+
+    public static bool SeatIsFilled(string[,] chart, int row, int column, int rowOffset = 0, int columnOffset = 0)
+    {
+        var rowIndex = row + rowOffset;
+        var columnIndex = column + columnOffset;
+
+        return SeatIsInboundAndFilled(chart, rowIndex, columnIndex);
+    }
+
+    private static bool SeatIsInboundAndFilled(string[,] chart, int row, int col)
+    {
+        return SeatIsInbound(chart, row, col)
+                && chart[row, col] != "x";
+    }
+
+    private static bool SeatIsInbound(string[,] chart, int row, int col)
+    {
+        return row > 0 && row < chart.GetLength(0)
+            && col > 0 && col < chart.GetLength(1);
+    }
+
+    public bool SeatIsInbound(int row, int column)
+    {
+        return SeatIsInbound(Chart, row, column);
+
+    }
+
 }

--- a/WebApp/Helpers/SeatingChart.cs
+++ b/WebApp/Helpers/SeatingChart.cs
@@ -33,6 +33,7 @@ namespace WebApp.Helpers
      */
     public class SeatingChart
     {
+        private Tuple<int, int> OpenSeat;
         public int Rows { get; }
         public int Columns { get; }
         public string[,] Chart { get; private set; }
@@ -46,10 +47,11 @@ namespace WebApp.Helpers
             Columns = columns;
             Chart = CreateDefaultSeatingChart(rows, columns);
             Students = students;
+            OpenSeat = new Tuple<int, int>(0, 0);
 
             FillChartWithStudents();
 
-            if (useAlternateFill) 
+            if (useAlternateFill)
             {
                 Chart = DistributeStudents(Chart, Students);
             }
@@ -59,14 +61,16 @@ namespace WebApp.Helpers
         private string[,] DistributeStudents(string[,] chart, List<StudentName> students)
         {
 
+            var newChart = CreateDefaultSeatingChart(Rows, Columns);
 
             
-            // for (int i = 0; i < Students.Count; i++)
-            // {
-            //     var studentName = Students[i];
-            //     (int row, int col) = GetFirstEmptySeat();
-            //     Chart[row, col] = studentName.FullName;
-            // }
+            for (int i = 0; i < Students.Count; i++)
+            {
+                var studentName = Students[i];
+                (int row, int col) = GetFirstEmptySeat();
+
+                Chart[row, col] = studentName.FullName;
+            }
 
             // (int row, int column) = GetFirstEmptyUncrowdedSeat();
             // bool everythingCrowded = row < 0 && column < 0;
@@ -112,23 +116,23 @@ namespace WebApp.Helpers
         {
             //use this method to collapse seating charts.
             //there's some function that can take a list of student names and a chart and spit one out that is collapsed
-                //it would be like
-                /*  func collapseFirstRow(numRows, numColumns, students)
-                    {
-                        //returns a new chart with the first row filled and the rest ... distributed?
+            //it would be like
+            /*  func collapseFirstRow(numRows, numColumns, students)
+                {
+                    //returns a new chart with the first row filled and the rest ... distributed?
 
-                        remainingStudents = students[numColumns...] 
-                        firstRowStudents = students[0..numColumns]
-                        var firstRowSeatingChart = new SeatingChart(1, columns, firstRowStudents);
-                        var firstRowChart = firstRowSeatingChart.Chart;
-                        var newSeatingChart = new SeatingChart(numRows - 1, columns, remainingStudents}
-                        
-                        return some amalgam of the current row that just got collapsed
-                        AND the remaining rows.
+                    remainingStudents = students[numColumns...] 
+                    firstRowStudents = students[0..numColumns]
+                    var firstRowSeatingChart = new SeatingChart(1, columns, firstRowStudents);
+                    var firstRowChart = firstRowSeatingChart.Chart;
+                    var newSeatingChart = new SeatingChart(numRows - 1, columns, remainingStudents}
+
+                    return some amalgam of the current row that just got collapsed
+                    AND the remaining rows.
 
 
-                    } */
-            
+                } */
+
             return seatingChart;
         }
 
@@ -169,14 +173,14 @@ namespace WebApp.Helpers
             return chart;
         }
 
-        public (int, int) GetFirstEmptyUncrowdedSeat()
+        public (int, int) GetFirstEmptyUncrowdedSeat(string[,] chart, int rows, int columns)
         {
             //walk each row left to right and find the first spot that isn't filled
-            for (int i = 0; i < Rows; i++)
+            for (int i = 0; i < rows; i++)
             {
-                for (int j = 0; j < Columns; j++)
+                for (int j = 0; j < columns; j++)
                 {
-                    if (Chart[i, j] == "x" && !IsCrowded(i, j))
+                    if (chart[i, j] == "x" && !IsCrowded(i, j))
                     {
                         return (i, j);
                     }
@@ -195,12 +199,21 @@ namespace WebApp.Helpers
 
         public (int, int) GetFirstEmptySeat()
         {
+            (int row, int col) = GetFirstEmptySeat(Chart, Rows, Columns);
+            OpenSeat = new Tuple<int, int>(row, col);
+
+            return (row, col);
+        }
+
+        private static (int, int) GetFirstEmptySeat(string[,] chart, int rows, int columns)
+        {
+            //TODO: possibly move to a SeatingChartFiller class or module?
             //walk each row left to right and find the first spot that isn't filled
-            for (int i = 0; i < Rows; i++)
+            for (int i = 0; i < rows; i++)
             {
-                for (int j = 0; j < Columns; j++)
+                for (int j = 0; j < columns; j++)
                 {
-                    if (Chart[i, j] == "x")
+                    if (chart[i, j] == "x")
                     {
                         return (i, j);
                     }
@@ -208,23 +221,6 @@ namespace WebApp.Helpers
             }
 
             return (-1, -1);
-        }
-        private string[,] PopulateSeatingChart(List<StudentName> students)
-        {
-
-            //possible solution for adding 
-            // var updatedChart = new string[_classPeriod.Rows, _classPeriod.Columns];
-            // for(var i = 0; i < _classPeriod.Rows; i++)
-            //     for(var j = 0; j < _classPeriod.Columns; j++) 
-
-
-            foreach (var student in students)
-            {
-                //always take a new list. never add to an existing structured chart. build the chart anew.
-                //foreach student in students : chart.add(student)
-
-            }
-            return Chart;
         }
 
         public bool HasEmptySpot()
@@ -242,6 +238,7 @@ namespace WebApp.Helpers
 
             return false;
         }
+
 
         public bool IsCrowded(int row, int column)
         {
@@ -295,8 +292,9 @@ namespace WebApp.Helpers
 
         public bool SeatIsInbound(int row, int column)
         {
-            return row >= 0 && row < Rows
-                    && column >= 0 && column < Columns;
+            return row > 0 && row < Chart.GetLength(0) 
+             && column > 0 && column < Chart.GetLength(1);
+            
         }
 
     }

--- a/WebApp/Helpers/SeatingChart.cs
+++ b/WebApp/Helpers/SeatingChart.cs
@@ -58,8 +58,41 @@ namespace WebApp.Helpers
 
         private string[,] DistributeStudents(string[,] chart, List<StudentName> students)
         {
+
+
             
+            // for (int i = 0; i < Students.Count; i++)
+            // {
+            //     var studentName = Students[i];
+            //     (int row, int col) = GetFirstEmptySeat();
+            //     Chart[row, col] = studentName.FullName;
+            // }
+
+            // (int row, int column) = GetFirstEmptyUncrowdedSeat();
+            // bool everythingCrowded = row < 0 && column < 0;
+
             return chart;
+
+
+            /*
+            * alternate approach to filling front before back:
+            * when no more uncrowded spots, collapse everything
+            * to fill first row. distribute everyone else in the remaining rows.
+            * - this can probably be done by simulating a seating chart with omitted students
+            * -- basically, if no more uncrowded spots, 
+                - fill first row by shifting everything to top left
+                - once first row is full, 
+                    - take all remaining names (subset of students)
+                    - create a new seating chart that's minus one row, fill with remaining names
+                    - get its output seating chart and replace remaining rows
+                    - do so until .... we're in the last spot
+
+                    given: students[0..10]
+                    return a new seating chart where 
+                        the first row consists of students[0..columns]
+                        and the rest consists of the same approach with a chart minus 1 row and remaining students
+            */
+
         }
 
         private static string[,] CreateDefaultSeatingChart(int rows, int columns)
@@ -78,6 +111,23 @@ namespace WebApp.Helpers
         public static SeatingChart CollapseFullSeatingChart(SeatingChart seatingChart)
         {
             //use this method to collapse seating charts.
+            //there's some function that can take a list of student names and a chart and spit one out that is collapsed
+                //it would be like
+                /*  func collapseFirstRow(numRows, numColumns, students)
+                    {
+                        //returns a new chart with the first row filled and the rest ... distributed?
+
+                        remainingStudents = students[numColumns...] 
+                        firstRowStudents = students[0..numColumns]
+                        var firstRowSeatingChart = new SeatingChart(1, columns, firstRowStudents);
+                        var firstRowChart = firstRowSeatingChart.Chart;
+                        var newSeatingChart = new SeatingChart(numRows - 1, columns, remainingStudents}
+                        
+                        return some amalgam of the current row that just got collapsed
+                        AND the remaining rows.
+
+
+                    } */
             
             return seatingChart;
         }
@@ -92,101 +142,13 @@ namespace WebApp.Helpers
             string[,] chart = CreateDefaultSeatingChart(Rows, Columns);
             Chart = FillChartWithStudents(chart);
 
-            // for (int i = 0; i < Students.Count; i++)
-            // {
-            //     var studentName = Students[i];
-            //     (int row, int col) = GetFirstEmptySeat();
-            //     Chart[row, col] = studentName.FullName;
-            // }
-
-            // (int row, int column) = GetFirstEmptyUncrowdedSeat();
-            // bool everythingCrowded = row < 0 && column < 0;
-
-            /*
-            * alternate approach to filling front before back:
-            * when no more uncrowded spots, collapse everything
-            * to fill first row. distribute everyone else in the remaining rows.
-            * - this can probably be done by simulating a seating chart with omitted students
-            * -- basically, if no more uncrowded spots, 
-                - fill first row by shifting everything to top left
-                - once first row is full, 
-                    - take all remaining names (subset of students)
-                    - create a new seating chart that's minus one row, fill with remaining names
-                    - get its output seating chart and replace remaining rows
-                    - do so until .... we're in the last spot
-
-                    given: students[0..10]
-                    return a new seating chart where the first row consists of students[0..column]
-                                            and the rest consists of the same approach with a chart minus 1row and students minus those that are filling the first row
-
-
-
-                if(noMoreUncrowdedSpots) { // need to figure out how to do this elegantly. there has to be a way. 
-                //something can be inferred about the classroom or the remaining names in a way that uses recursion. 
-                //there's some function that can take a list of student names and a chart and spit one out that is collapsed
-                //it would be like
-                    func collapseFirstRow()
-                    {
-                        //returns a new seating chart object with the first row filled and the rest ... distributed?
-
-                        remainingStudents = students[columns..?] 
-                        var newChart = new SeatingChart = new { rows = Rows - 1, columns = Columns, Students = remainingStudents}
-                        return some amalgam of the current row that just got collapsed
-                        AND the remaining rows.
-                        so... 
-                        currentRow = 0;
-                        for(var i = currentRow; i < columns; i++) {
-                            if(students[i])
-                                chart[currentRow, i] = students[i]
-                        }
-
-                    }
-
-
-
-
-                    studentNamesToFillRow = students.from(row*column..(row+1)*column)
-                    chart
-
-                }
-            */
-            // if (!everythingCrowded)
-            // {
-            //     foreach (var studentName in Students)
-            //     {
-
-            //         if (!IsCrowded(row, column))
-            //         {
-            //             Chart[row, column] = studentName.FullName;
-            //         }
-            //         else
-            //         {
-            //             //keep walking, but ... default to here
-            //             /* find first empty spot */
-            //             /*
-            //              * GIVEN an empty spot AND no uncrowded spots, 
-            //              * WHEN determining where to insert, 
-            //             */
-            //         }
-
-            //     }
-            // }
-            // else 
-            // {
-            //     //everything is crowded. 
-            //     // if there is 1 empty spot that's not at the end
-            //     // we still need to insert at end, so... 
-            //     /*
-            //     * 1. shift everything to top-left
-            //     */
-            // }
         }
 
         private string[,] FillChartWithStudents(string[,] emptyChart)
         {
             var chart = emptyChart;
 
-            //TODO: eventually get to a method of "if there's no uncrowded spot, then collapse chart and put it int the spot that's one off from the last filled spot"
+            //TODO: deal with waitlist or trim students?
             for (int i = 0; i < Rows; i++)
             {
                 for (int j = 0; j < Columns; j++)


### PR DESCRIPTION
This pull request implements second student insert using alt fill (optimized, distanced seating) rules
Expected to place the 2nd student correctly in the following grids:

- 1x2: [0,1]
- 1x3: [0,2]
- 1x4: [0,2]
- 2x1: [1,0]
- 3x1: [2,0]
- 4x1: [2,0]
- 2x2: [1,1]
- 2x3: [0,2]
- 3x2: [1,1]